### PR TITLE
Disable postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "scripts/build",
     "dist": "scripts/dist",
-    "postinstall": "scripts/postinstall",
+    "_postinstall": "scripts/postinstall",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "prepublishOnly": "scripts/prepublishOnly",


### PR DESCRIPTION
## What

- disable `postinstall` script

## Why

- ﻿`postinstall` script should be disabled by default to avoid issues when we install the package as dependency

