### PR TITLE
fix(pub): adds npmignore to allow build in install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 package-lock.json
+.npmignore

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@rsksmart/rif-relay-common",
-  "version": "0.0.2-alpha.3",
+  "version": "0.0.2-alpha.4",
   "description": "This project contains all the common code for the rif relay system.",
   "main": "dist/index.js",
   "scripts": {
+    "prepack": "npmignore --auto",
     "prepare": "scripts/prepare",
     "build": "scripts/build",
     "lint": "eslint . --ext .ts",
@@ -16,10 +17,19 @@
   },
   "author": "Relaying Services Team",
   "license": "MIT",
+  "publishConfig": {
+    "ignore": [
+      "!dist",
+      "!build",
+      "src",
+      "test",
+      ".github"
+    ]
+  },
   "dependencies": {
     "@openeth/truffle-typings": "0.0.6",
     "@openzeppelin/contracts": "~3.2.0",
-    "@rsksmart/rif-relay-contracts": "0.0.2-alpha.2",
+    "@rsksmart/rif-relay-contracts": "0.0.2-alpha.4",
     "@truffle/abi-utils": "~0.2.3",
     "@truffle/contract": "~4.2.23",
     "@truffle/contract-schema": "3.3.2",
@@ -37,6 +47,7 @@
     "ethereumjs-util": "~6.2.1",
     "ethval": "~2.1.1",
     "loglevel": "~1.7.0",
+    "npmignore": "^0.3.0",
     "ow": "~0.17.0",
     "patch-package": "~6.4.6",
     "semver": "~7.3.2",

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -2,4 +2,6 @@
 
 patch-package
 
+npm run build && npm run dist
+
 husky install


### PR DESCRIPTION
## What

- adds auto `.npmignore`

## Why

- this will allow the `build/` and `dist/` folders to be created when this package is installed
- the auto option is enabled to release the entanglement of `.npmignore` with `.gitignore`

## Refs
- relates to https://rsklabs.atlassian.net/browse/PP-166
- source: https://www.npmjs.com/package/npmignore
