### PR TITLE
feature/PP-171

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-relay-common",
-  "version": "0.0.2-alpha.4",
+  "version": "0.0.2-alpha.5",
   "description": "This project contains all the common code for the rif relay system.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/types/EnvelopingTransactionDetails.ts
+++ b/src/types/EnvelopingTransactionDetails.ts
@@ -49,6 +49,11 @@ export default interface EnvelopingTransactionDetails {
      */
     readonly onlyPreferredRelays?: boolean;
 
+    /**
+     * Use this to wait for the transaction receipt while processing a transaction
+     */
+    readonly waitForTransactionReceipt?: boolean;
+
     retries?: number;
     initialBackoff?: number;
 }


### PR DESCRIPTION
## What

- Created a transaction history modal to be able to verify the transactions for each smart wallet
- 
## Why

- With the current implementation, each time the users try to execute a transaction, they need to wait until it is confirmed (or rejected). To avoid this, we could provide the user with the link to the explorer.

## Refs

- [Jira issue](https://rsklabs.atlassian.net/browse/PP-171)
