### PR TITLE
PP-127: optional collector

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@openeth/truffle-typings": "0.0.6",
     "@openzeppelin/contracts": "~3.2.0",
     "@truffle/abi-utils": "~0.2.3",
-    "@rsksmart/rif-relay-contracts": "https://github.com/rsksmart/rif-relay-contracts#PP-94/optional-collector",
+    "@rsksmart/rif-relay-contracts": "https://github.com/rsksmart/rif-relay-contracts#PP-94/revenue-sharing-model",
     "@truffle/contract": "~4.2.23",
     "bn.js": "5.1.2",
     "chalk": "~4.1.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@openeth/truffle-typings": "0.0.6",
     "@openzeppelin/contracts": "~3.2.0",
     "@truffle/abi-utils": "~0.2.3",
-    "@rsksmart/rif-relay-contracts": "https://github.com/rsksmart/rif-relay-contracts#PP-94/revenue-sharing-model",
+    "@rsksmart/rif-relay-contracts": "https://github.com/rsksmart/rif-relay-contracts#PP-94/optional-collector",
     "@truffle/contract": "~4.2.23",
     "bn.js": "5.1.2",
     "chalk": "~4.1.0",

--- a/src/PingResponse.ts
+++ b/src/PingResponse.ts
@@ -2,6 +2,7 @@ export default interface PingResponse {
     relayWorkerAddress: string;
     relayManagerAddress: string;
     relayHubAddress: string;
+    collectorAddress?: string;
     minGasPrice: string;
     networkId?: string;
     chainId?: string;

--- a/src/PingResponse.ts
+++ b/src/PingResponse.ts
@@ -2,7 +2,7 @@ export default interface PingResponse {
     relayWorkerAddress: string;
     relayManagerAddress: string;
     relayHubAddress: string;
-    collectorAddress?: string;
+    feesReceiver: string;
     minGasPrice: string;
     networkId?: string;
     chainId?: string;

--- a/src/types/EnvelopingTransactionDetails.ts
+++ b/src/types/EnvelopingTransactionDetails.ts
@@ -6,7 +6,6 @@ export default interface EnvelopingTransactionDetails {
     readonly data: PrefixedHexString;
     readonly to: string;
     readonly tokenContract?: string;
-    readonly collectorContract?: string;
     readonly tokenAmount?: string;
     tokenGas?: string;
     readonly recoverer?: string;

--- a/src/types/RelayTransactionRequest.ts
+++ b/src/types/RelayTransactionRequest.ts
@@ -34,7 +34,7 @@ export const DeployTransactionRequestShape = {
         },
         relayData: {
             gasPrice: ow.string,
-            relayWorker: ow.string,
+            feesReceiver: ow.string,
             callForwarder: ow.string,
             callVerifier: ow.string
         }
@@ -57,13 +57,12 @@ export const RelayTransactionRequestShape = {
             nonce: ow.string,
             data: ow.string,
             tokenContract: ow.string,
-            collectorContract: ow.string,
             tokenAmount: ow.string,
             tokenGas: ow.string
         },
         relayData: {
             gasPrice: ow.string,
-            relayWorker: ow.string,
+            feesReceiver: ow.string,
             callForwarder: ow.string,
             callVerifier: ow.string
         }


### PR DESCRIPTION
## What

- added relayWorker parameter in many functions
- included collector address in ping response interface
- removed collector field from certain types and interfaces
- validations no longer consider a collector field
- replaces relayWorker with feesReceiver in relayRequest interfaces, types and objects

## Why

- this allows for the separation between the concepts of feesReceiver and collector Address. The fees receiver can be th relay worker or the collector address if there is a revenue sharing strategy involved.

## Refs

- PP-94, PP-127
