### PR TITLE
build: fix the openeth/truffle-typings patch

### DIFF
--- a/patches/@openeth+truffle-typings+0.0.6.patch
+++ b/patches/@openeth+truffle-typings+0.0.6.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@openeth/truffle-typings/index.d.ts b/node_modules/@openeth/truffle-typings/index.d.ts
-index 5de91fb..85cf390 100644
+index 5de91fb..86d9264 100644
 --- a/node_modules/@openeth/truffle-typings/index.d.ts
 +++ b/node_modules/@openeth/truffle-typings/index.d.ts
-@@ -46,11 +46,15 @@ declare namespace Truffle {
+@@ -46,11 +46,14 @@ declare namespace Truffle {
      gas?: BN | number | string;
      gasPrice?: BN | number | string;
      value?: BN | string;
@@ -18,7 +18,6 @@ index 5de91fb..85cf390 100644
 +    tokenAmount?: BN | number | string;
 +    tokenContract?: string;
 +    forceGas?: BN | number | string;
-+    collectorContract?: string;
    }
  
    export interface TransactionLog {


### PR DESCRIPTION
## What

- Update the @openeth/truffle-typings patch

## Why

- Because we removed the collectorContract field (see the [related commit](https://github.com/rsksmart/rif-relay-contracts/pull/51/files#diff-04a855f917c6e3a996e2d0d2c77d7775b5479badad514d2ecfd26d25ebf9cb55) in the contract repo)

